### PR TITLE
feat(filebrowser): add extension filtering to FileBrowserSystem::open

### DIFF
--- a/lib/ftk/UI/FileBrowser.h
+++ b/lib/ftk/UI/FileBrowser.h
@@ -233,12 +233,18 @@ namespace ftk
             const std::shared_ptr<Context>&);
 
         //! Open the file browser.
+        //!
+        //! The filter extensions (e.g. { ".djvr" }) restrict both the native and
+        //! the built-in dialog to those file types; an empty list shows all
+        //! files. The filter name labels the group in the native dialog.
         FTK_API void open(
             const std::shared_ptr<IWindow>&,
             const std::function<void(const Path&)>&,
             const std::string& title = "Open",
             const std::filesystem::path& = std::filesystem::path(),
-            FileBrowserMode = FileBrowserMode::Open);
+            FileBrowserMode = FileBrowserMode::Open,
+            const std::vector<std::string>& filterExtensions = {},
+            const std::string& filterName = "Supported");
 
         //! Get whether the native file dialog is used.
         FTK_API bool isNativeFileDialog() const;

--- a/lib/ftk/UI/FileBrowserSystem.cpp
+++ b/lib/ftk/UI/FileBrowserSystem.cpp
@@ -59,19 +59,54 @@ namespace ftk
         const std::function<void(const Path&)>& callback,
         const std::string& title,
         const std::filesystem::path& path,
-        FileBrowserMode mode)
+        FileBrowserMode mode,
+        const std::vector<std::string>& filterExtensions,
+        const std::string& filterName)
     {
         FTK_P();
         bool native = p.native;
 #if defined(FTK_NFD)
         if (native)
         {
+            // Build a single native filter group from the extensions. NFD wants
+            // a comma-separated spec without leading dots, e.g. "djvr" or
+            // "png,jpg".
+            std::string spec;
+            for (const auto& ext : filterExtensions)
+            {
+                std::string e = ext;
+                if (!e.empty() && '.' == e.front())
+                {
+                    e.erase(0, 1);
+                }
+                if (e.empty())
+                {
+                    continue;
+                }
+                if (!spec.empty())
+                {
+                    spec += ",";
+                }
+                spec += e;
+            }
+            std::vector<nfdu8filteritem_t> filterItems;
+            if (!spec.empty())
+            {
+                filterItems.push_back({ filterName.c_str(), spec.c_str() });
+            }
+            const nfdu8filteritem_t* filterList = filterItems.empty() ? nullptr : filterItems.data();
+            const nfdfiltersize_t filterCount = static_cast<nfdfiltersize_t>(filterItems.size());
+            const std::string defaultPathStr = path.u8string();
+            const nfdu8char_t* defaultPath = defaultPathStr.empty() ? nullptr : defaultPathStr.c_str();
+
             nfdu8char_t* outPath = nullptr;
             switch (mode)
             {
             case FileBrowserMode::Open:
+                NFD::OpenDialog(outPath, filterList, filterCount, defaultPath);
+                break;
             case FileBrowserMode::Save:
-                NFD::OpenDialog(outPath);
+                NFD::SaveDialog(outPath, filterList, filterCount, defaultPath);
                 break;
             case FileBrowserMode::Dir:
                 NFD::PickFolder(outPath);
@@ -91,12 +126,22 @@ namespace ftk
         {
             if (auto context = _context.lock())
             {
+                // When a filter is given, use a dedicated model so the shared
+                // model (configured elsewhere, e.g. for media) is left untouched.
+                std::shared_ptr<FileBrowserModel> model = p.model;
+                if (!filterExtensions.empty())
+                {
+                    model = FileBrowserModel::create(context);
+                    model->setOptions(p.model->getOptions());
+                    model->setExts(filterExtensions);
+                    model->setExt(filterExtensions.front());
+                }
                 p.fileBrowser = FileBrowser::create(
                     context,
                     title,
                     path,
                     mode,
-                    p.model);
+                    model);
                 p.fileBrowser->setTitle(title);
                 p.fileBrowser->setRecentFilesModel(p.recentFilesModel);
                 p.fileBrowser->open(window);


### PR DESCRIPTION
`FileBrowserSystem::open()` currently shows every file, and uses an open
dialog even when the caller asked for `FileBrowserMode::Save`. Callers that
work with one file type have no way to say so.

This adds two optional parameters, `filterExtensions` and `filterName`:

- The native path builds a single NFD filter group from the extensions, and
  `FileBrowserMode::Save` now maps to `NFD::SaveDialog` rather than reusing
  `NFD::OpenDialog`. Both modes also honour the requested default path, which
  was previously ignored.
- The built-in path uses a dedicated `FileBrowserModel` when a filter is
  given, so the shared model — configured elsewhere, e.g. for media — is left
  untouched.

An empty extension list keeps the previous behaviour exactly, so existing
callers are unaffected.

The motivation is a review-session feature in DJV that saves and opens
`.djvr` documents and needs the dialog restricted to them, but nothing here
is specific to DJV.

Based on current `main`; the two files it touches have not changed upstream
since.
